### PR TITLE
Added an additional check to see if HTTP_ACCEPT is explicitly set

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -80,7 +80,7 @@ class webservice_restjson_server extends webservice_base_server {
         $methodvariables = array_merge($_GET, (array) $data);
 
         // Check accept header for accepted responses.
-        if (isset($_SERVER["HTTP_ACCEPT"])) {
+        if (isset($_SERVER["HTTP_ACCEPT"]) && $_SERVER['HTTP_ACCEPT'] != "*/*") {
             $accept = array_map('trim', explode(',', $_SERVER["HTTP_ACCEPT"]));
             if (!empty($accept)) {
                 if (!in_array('application/xml', $accept)) {


### PR DESCRIPTION
When the HTTP_ACCEPT header is not explicitly set, the value is set by default `*/*` for me. So I added an additional condition when checking if the $_SERVER["HTTP_ACCEPT"] value is set or not. 

I.e, is it set AND is it not the value `*/*`
