### PR TITLE
Fix incorrect path for locallib in simple server

### DIFF
--- a/simpleserver.php
+++ b/simpleserver.php
@@ -31,9 +31,9 @@ define('NO_DEBUG_DISPLAY', true);
 define('WS_SERVER', true);
 
 require('../../config.php');
-require_once("$CFG->dirroot/webservice/rest/locallib.php");
+require_once("$CFG->dirroot/webservice/restjson/locallib.php");
 
-if (!webservice_protocol_is_enabled('rest')) {
+if (!webservice_protocol_is_enabled('restjson')) {
     die;
 }
 


### PR DESCRIPTION
The path of the webservice library had not been updated after being copied from the built in rest webservice. This commit fixes the invalid path and also updates the check for the webservice being enabled.