### PR TITLE
Update locallib.php

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -25,6 +25,8 @@
 
 require_once("$CFG->dirroot/webservice/lib.php");
 
+use core_external\external_api;
+
 /**
  * REST service server implementation.
  *


### PR DESCRIPTION
This removes the Error Class \external_api not found on PHP 8.3